### PR TITLE
test: use the right diff()

### DIFF
--- a/diffimg/test.py
+++ b/diffimg/test.py
@@ -5,7 +5,7 @@ import unittest
 
 import PIL
 
-from diff import diff
+from diffimg.diff import diff
 
 IMAGES_DIR = "images"
 


### PR DESCRIPTION
a test failed while packaging this for Nixpkgs, this fixes it

side note: for packaging it would be convenient if releases were tagged in git, preferably without a leading `v`